### PR TITLE
Improve `arrivals_and_departures_for_stop` example

### DIFF
--- a/examples/arrivals_and_departures_for_stop.py
+++ b/examples/arrivals_and_departures_for_stop.py
@@ -15,16 +15,10 @@ settings = load_settings(
 # Create a new instance of the OneBusAway SDK with the settings we loaded.
 oba = OnebusawaySDK(**settings)
 
-# Define the query parameters
-query = {
-    "tripId": "1_604670535",  # Replace with actual trip ID
-    "serviceDate": "1810918000000",  # Replace with actual service date in milliseconds since epoch
-}
-
-stopId = "1_75403"  # Replace with actual stop ID
+stopId = "1_19750"  # Replace with actual stop ID
 
 # Retrieve arrival and departure information
-response = oba.arrival_and_departure.list(stopId, extra_query=query)
+response = oba.arrival_and_departure.list(stopId)
 
 # Example to access specific data
 arrivals_and_departures = response.data.entry.arrivals_and_departures

--- a/examples/arrivals_and_departures_for_stop.py
+++ b/examples/arrivals_and_departures_for_stop.py
@@ -1,4 +1,5 @@
 from helpers.load_env import load_settings
+from helpers.formatters import bold, format_timestamp
 
 from onebusaway import OnebusawaySDK
 
@@ -24,9 +25,13 @@ response = oba.arrival_and_departure.list(stopId)
 arrivals_and_departures = response.data.entry.arrivals_and_departures
 
 for arr_dep in arrivals_and_departures:
-    print(f"Route: {arr_dep.route_short_name}")
-    print(f"Trip Headsign: {arr_dep.trip_headsign}")
-    print(f"Predicted Arrival Time: {arr_dep.predicted_arrival_time}")
-    print(f"Scheduled Arrival Time: {arr_dep.scheduled_arrival_time}")
+    has_realtime_data = arr_dep.predicted_arrival_time > 0
+
+    print(f"{bold(arr_dep.route_short_name)} - {arr_dep.trip_headsign}")
+
+    if arr_dep.predicted_arrival_time > 0:
+        print(f"Predicted Arrival Time: {format_timestamp(arr_dep.predicted_arrival_time)}")
+
+    print(f"Scheduled Arrival Time: {format_timestamp(arr_dep.scheduled_arrival_time)}")
     print(f"Vehicle ID: {arr_dep.vehicle_id}")
     print("")

--- a/examples/helpers/formatters.py
+++ b/examples/helpers/formatters.py
@@ -1,0 +1,39 @@
+from datetime import datetime
+
+# ANSI escape codes for text formatting
+BOLD = '\033[1m'
+RED = '\033[31m'
+GREEN = '\033[32m'
+BLUE = '\033[34m'
+RESET = '\033[0m'
+
+def format_timestamp(timestamp_ms: int) -> str:
+    """
+    Format a Unix timestamp in milliseconds to a human-readable time.
+    """
+    local_time = datetime.fromtimestamp(timestamp_ms / 1000)
+    return local_time.strftime('%I:%M:%S %p')
+
+def bold(text: str) -> str:
+    """
+    Return the text in bold.
+    """
+    return f"{BOLD}]{text}{RESET}"
+
+def green(text: str) -> str:
+    """
+    Return the text in green.
+    """
+    return f"{GREEN}{text}{RESET}"
+
+def blue(text: str) -> str:
+    """
+    Return the text in blue.
+    """
+    return f"{BLUE}{text}{RESET}"
+
+def red(text: str) -> str:
+    """
+    Return the text in red.
+    """
+    return f"{RED}{text}{RESET}"

--- a/examples/helpers/formatters.py
+++ b/examples/helpers/formatters.py
@@ -18,7 +18,7 @@ def bold(text: str) -> str:
     """
     Return the text in bold.
     """
-    return f"{BOLD}]{text}{RESET}"
+    return f"{BOLD}{text}{RESET}"
 
 def green(text: str) -> str:
     """


### PR DESCRIPTION
[Change the URL of the arrivals_and_departures_for_stop sample](https://github.com/aaronbrethorst/oba-python-sdk/commit/e4f8605aa10eb32901ef8e130edffbb106966a74) 
* Change the `stopId` to a stop served only by a single route to make it easier to parse
* Remove unused `extra_query` params

[Improve arrivals_and_departures_for_stop output](https://github.com/aaronbrethorst/oba-python-sdk/commit/0b3ebb813a770700a6778810bc636989aa10c272) 
* Use bold text to render the `route_short_name`
* Only show the `predicted_arrival_time` if it's available
* Add a `format_timestamp` method to format the arrival timestamps